### PR TITLE
Update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -651,9 +651,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     }
   ],
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   }
 }

--- a/test/cookie-sessions.test.js
+++ b/test/cookie-sessions.test.js
@@ -133,7 +133,8 @@ describe('cookie sessions tests', function() {
 
     describe('when session has already data', function() {
       beforeEach(function() {
-        this.sandbox.stub(sessions, 'deserialize').returns({data: {username: 'foobar'}, time: 1540684048566});
+        this.cookieTime = Date.now()
+        this.sandbox.stub(sessions, 'deserialize').returns({data: {username: 'foobar'}, time: this.cookieTime});
       });
 
       describe('and new data are added to req.session', function() {
@@ -152,7 +153,7 @@ describe('cookie sessions tests', function() {
               assert(res.headers['set-cookie'])
               _node = res.headers['set-cookie'][0].split(';')[0].split('=')[1]
               var jsonData = sessions.deserialize(secret, decodeURIComponent(_node), 1000 * 60 * 60 * 24)
-              assert.notEqual(jsonData.time, 1540684048566)
+              assert.notEqual(jsonData.time, this.cookieTime)
               assert.deepEqual(jsonData.data, { username: 'foobar', koko: 'bar' })
             })
           });
@@ -172,7 +173,7 @@ describe('cookie sessions tests', function() {
               assert(res.headers['set-cookie'])
               var _node = res.headers['set-cookie'][0].split(';')[0].split('=')[1]
               var jsonData = sessions.deserialize(secret, decodeURIComponent(_node), 1000 * 60 * 60 * 24)
-              assert.equal(jsonData.time, 1540684048566)
+              assert.equal(jsonData.time, this.cookieTime)
               assert.deepEqual(jsonData.data, { username: 'foobar', koko: 'bar' })
             })
           });
@@ -193,7 +194,7 @@ describe('cookie sessions tests', function() {
               assert(res.headers['set-cookie'])
               var _node = res.headers['set-cookie'][0].split(';')[0].split('=')[1]
               var jsonData = sessions.deserialize(secret, decodeURIComponent(_node), 1000 * 60 * 60 * 24)
-              assert.notEqual(jsonData.time, 1540684048566)
+              assert.notEqual(jsonData.time, this.cookieTime)
               assert.deepEqual(jsonData.data, { username: 'foobar'})
             })
           });


### PR DESCRIPTION
### Description

Snyk reports that lodash@4.17.11 has a vulnerability: https://app.snyk.io/vuln/SNYK-JS-LODASH-450202
This PR updates the lodash version to ^4.17.14 address this issue. Also it fixes a bug in tests that caused the test suite to fail: There was a hardcoded cookie timestamp which resulted the valid() function returning that the cookie has expired

### References
 https://app.snyk.io/vuln/SNYK-JS-LODASH-450202

### Testing
`npm test` passes successfully

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
